### PR TITLE
Inherit from abstract controller

### DIFF
--- a/src/ClassificationTreeBundle/Controller/DefaultController.php
+++ b/src/ClassificationTreeBundle/Controller/DefaultController.php
@@ -7,7 +7,7 @@
 namespace Divante\ClassificationTreeBundle\Controller;
 
 use Divante\ClassificationTreeBundle\Service\ClassificationTreeBuilder;
-use Pimcore\Bundle\AdminBundle\Controller\Admin\DataObject\DataObjectController;
+use Pimcore\Bundle\AdminBundle\Controller\AdminController;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -18,7 +18,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
  * @package Divante\ClassificationTreeBundle\Controller
  * @Route("/admin/classification-tree")
  */
-class DefaultController extends DataObjectController
+class DefaultController extends AdminController
 {
     /** @var  ClassificationTreeBuilder */
     protected $treeBuilderService;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

## Changes
### Changed
- Controller inherits from abstract admin controller instead of data object controller (causes a problem with admin templates in Pimcore 6.6.5+)